### PR TITLE
Use eclipse and jlink to migrate to bookworm

### DIFF
--- a/.idea/docker-image-jodconverter-runtime.iml
+++ b/.idea/docker-image-jodconverter-runtime.iml
@@ -6,4 +6,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="SonarLintModuleSettings">
+    <option name="uniqueId" value="81275b98-b250-4793-b72c-8a9f892df9aa" />
+  </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
-FROM bellsoft/liberica-openjre-debian:17
+FROM eclipse-temurin:21-jdk-focal as javabase
+ARG TARGET_BASE_IMAGE=debian:bookworm
+ENV JAVA_MODULES=java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.incubator.foreign,jdk.incubator.vector,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules $JAVA_MODULES \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /jre
+
+############ JRE ############
+FROM $TARGET_BASE_IMAGE as jre
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=javabase /jre $JAVA_HOME
+
 RUN apt-get update && apt-get -y install \
   apt-transport-https locales-all libpng16-16 libxinerama1 libgl1-mesa-glx libfontconfig1 libfreetype6 libxrender1 \
   libxcb-shm0 libxcb-render0 adduser cpio findutils gosu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET_BASE_IMAGE=debian:bookworm
 
 FROM eclipse-temurin:21-jdk-jammy as javabase
-ENV JAVA_MODULES=java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.incubator.foreign,jdk.incubator.vector,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs
+ENV JAVA_MODULES=java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.incubator.vector,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs
 
 RUN $JAVA_HOME/bin/jlink \
     --add-modules $JAVA_MODULES \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM eclipse-temurin:21-jdk-focal as javabase
 ARG TARGET_BASE_IMAGE=debian:bookworm
+
+FROM eclipse-temurin:21-jdk-jammy as javabase
 ENV JAVA_MODULES=java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.incubator.foreign,jdk.incubator.vector,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs
 
 RUN $JAVA_HOME/bin/jlink \
@@ -11,6 +12,7 @@ RUN $JAVA_HOME/bin/jlink \
     --output /jre
 
 ############ JRE ############
+ARG TARGET_BASE_IMAGE=debian:bookworm
 FROM $TARGET_BASE_IMAGE as jre
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Eugen Mayer
+Copyright (c) 2019-2023 Eugen Mayer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ for example projects build on top of this runtime, running JODconverter example 
 
 ## Builds info
 
-- Official OpenJDK 17 Java (bellsoft debian based)(since that is what we want with docker)
-- LibreOffice is 6.1.5+ right now
+- Official debian/bookworm with OpenJDK 21 Java (eclipse/temurin jlink based)
+- LibreOffice is 7+ right now
 
 Hint: We cannot split [JODconverter](https://github.com/jodconverter/jodconverter) and LibreOffice into two separate images since for now, `JODconverter` has to be running on the same machine as LibreOffice.
 The main reason behind this is, that [JODconverter](https://github.com/jodconverter/jodconverter) does manage the LibreOffice instances itself, starts and stop them. It does not just connect to it (and if, it uses a local socket)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for example projects build on top of this runtime, running JODconverter example 
 ## Builds info
 
 - Official debian/bookworm with OpenJDK 21 Java (eclipse/temurin jlink based)
-- LibreOffice is 7+ right now
+- LibreOffice is 7.4.+ right now
 
 Hint: We cannot split [JODconverter](https://github.com/jodconverter/jodconverter) and LibreOffice into two separate images since for now, `JODconverter` has to be running on the same machine as LibreOffice.
 The main reason behind this is, that [JODconverter](https://github.com/jodconverter/jodconverter) does manage the LibreOffice instances itself, starts and stop them. It does not just connect to it (and if, it uses a local socket)


### PR DESCRIPTION
Migrate baseimage to bookworm

- upgrades libreoffice
- run under jre 21
- use eclipse-temurin with jlink to build the runtime jre