### PR TITLE
Defaults the characterset encoding to UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ ENV PATH "${JAVA_HOME}/bin:${PATH}"
 ENV NONPRIVUSER=jodconverter
 ENV NONPRIVGROUP=jodconverter
 
+# Set default characterset encoding to UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 COPY --from=jresource /jre $JAVA_HOME
 
 # using backports for libreoffice 24.x (bookworm has 7.x)


### PR DESCRIPTION
This change allows converting files with filenames that are not present in the current US-ASCII charset

With the current US-ASCII charset, the error ´java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: Ødegaard.docx´ is thrown when trying to convert files with UTF-8 characters (like Æ, Ø and Å in Norway)